### PR TITLE
Support for extra Prometheus labels

### DIFF
--- a/bento2seldon/bento.py
+++ b/bento2seldon/bento.py
@@ -223,10 +223,10 @@ class BasePredictor(
     ) -> None:
         if reward is not None:
             extra = {}
-            if request is not None and hasattr(self, "_extra_monitor_request_info"):
+            if request is not None and hasattr(self, "extra_monitor_request_info"):
                 extra = {
                     label: getattr(request.jsonData, label)
-                    for label in self._extra_monitor_request_info
+                    for label in self.extra_monitor_request_info
                 }
 
             self._monitor.observe_reward(reward, extra=extra)

--- a/bento2seldon/bento.py
+++ b/bento2seldon/bento.py
@@ -222,7 +222,14 @@ class BasePredictor(
         routing: Optional[int],
     ) -> None:
         if reward is not None:
-            self._monitor.observe_reward(reward)
+            extra = {}
+            if request is not None and hasattr(self, "_extra_monitor_request_info"):
+                extra = {
+                    label: getattr(request.jsonData, label)
+                    for label in self._extra_monitor_request_info
+                }
+
+            self._monitor.observe_reward(reward, extra=extra)
 
     @api(route="send-feedback", input=SeldonJsonInput(), batch=False)
     def send_feedback(

--- a/bento2seldon/bento.py
+++ b/bento2seldon/bento.py
@@ -202,6 +202,10 @@ class BasePredictor(
         pass
 
     @property
+    def extra_monitoring_request_fields(self) -> List[str]:
+        return []
+
+    @property
     def cache(self) -> Cache[RT, RE]:
         if not hasattr(self, "_cache"):
             self._cache = Cache[RT, RE](
@@ -223,10 +227,10 @@ class BasePredictor(
     ) -> None:
         if reward is not None:
             extra = {}
-            if request is not None and hasattr(self, "extra_monitor_request_info"):
+            if request is not None:
                 extra = {
                     label: getattr(request.jsonData, label)
-                    for label in self.extra_monitor_request_info
+                    for label in self.extra_monitoring_request_fields
                 }
 
             self._monitor.observe_reward(reward, extra=extra)

--- a/bento2seldon/bento.py
+++ b/bento2seldon/bento.py
@@ -59,9 +59,7 @@ logger = logging.getLogger(__name__)
 
 class ExceptionHandler:
     def __init__(
-        self,
-        tasks: List[InferenceTask],
-        logging_context: LoggingContext,
+        self, tasks: List[InferenceTask], logging_context: LoggingContext,
     ):
         self._tasks = tasks
         self._logging_context = logging_context
@@ -88,6 +86,21 @@ class ExceptionHandler:
                 return func(*args, **kwargs)
 
         return decorate(f, wrapped)
+
+
+class ExtraMonitoringHandler:
+    @property
+    def extra_monitoring_request_fields(self) -> List[str]:
+        return []
+
+    def extract_fields_from_request(
+        self, request: Optional[SeldonMessage[RT]] = None
+    ) -> Dict[str, Any]:
+        if request is not None:
+            return {
+                label: getattr(request.jsonData, label)
+                for label in self.extra_monitoring_request_fields
+            }
 
 
 class BaseBentoService(BentoService, metaclass=abc.ABCMeta):
@@ -173,14 +186,11 @@ class BaseBentoServiceWithResponse(
     ) -> Dict[str, Any]:
         if meta:
             seldon_message_response = SeldonMessage[self.response_type](  # type: ignore[name-defined]
-                status=Status(),
-                meta=meta,
-                jsonData=response,
+                status=Status(), meta=meta, jsonData=response,
             )
         else:
             seldon_message_response = SeldonMessage[self.response_type](  # type: ignore[name-defined]
-                status=Status(),
-                jsonData=response,
+                status=Status(), jsonData=response,
             )
         return seldon_message_response.dict(exclude_none=True)
 
@@ -194,16 +204,15 @@ class BaseBentoServiceWithResponse(
 
 
 class BasePredictor(
-    BaseBentoServiceWithResponse[RE], Generic[RT, RE], metaclass=abc.ABCMeta
+    BaseBentoServiceWithResponse[RE],
+    Generic[RT, RE],
+    ExtraMonitoringHandler,
+    metaclass=abc.ABCMeta,
 ):
     @property
     @abc.abstractmethod
     def request_type(self) -> Type[RT]:
         pass
-
-    @property
-    def extra_monitoring_request_fields(self) -> List[str]:
-        return []
 
     @property
     def cache(self) -> Cache[RT, RE]:
@@ -226,14 +235,9 @@ class BasePredictor(
         routing: Optional[int],
     ) -> None:
         if reward is not None:
-            extra = {}
-            if request is not None:
-                extra = {
-                    label: getattr(request.jsonData, label)
-                    for label in self.extra_monitoring_request_fields
-                }
-
-            self._monitor.observe_reward(reward, extra=extra)
+            self._monitor.observe_reward(
+                reward, extra=self.extract_fields_from_request(request)
+            )
 
     @api(route="send-feedback", input=SeldonJsonInput(), batch=False)
     def send_feedback(
@@ -351,10 +355,7 @@ class BaseBatchPredictor(BasePredictor[RT, RE], Generic[RT, RE], metaclass=abc.A
         pass
 
     @api(
-        input=SeldonJsonInput(),
-        batch=True,
-        mb_max_latency=1000,
-        mb_max_batch_size=100,
+        input=SeldonJsonInput(), batch=True, mb_max_latency=1000, mb_max_batch_size=100,
     )
     def predict(
         self,
@@ -454,9 +455,7 @@ class BaseCombiner(
 
     @api(input=SeldonJsonInput(), batch=False)
     def aggregate(
-        self,
-        raw_seldon_message_list: List[Dict[str, Any]],
-        task: InferenceTask = None,
+        self, raw_seldon_message_list: List[Dict[str, Any]], task: InferenceTask = None,
     ) -> Optional[Dict[str, Any]]:
         logging_context = self.get_logger_context(endpoint="aggregate")
         logger.debug("/aggregate: %s", raw_seldon_message_list, extra=logging_context)

--- a/bento2seldon/monitoring.py
+++ b/bento2seldon/monitoring.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type
 
 from bentoml import BentoService, config
 from prometheus_client import Counter, Histogram
@@ -13,35 +13,10 @@ FEEDBACK_ENDPOINT = "send-feedback"
 
 
 class Monitor:
-    def __init__(
-        self,
-        bento_service: BentoService,
-        extra_labels_per_metric: Optional[Dict[str, List[str]]] = {},
-    ) -> None:
+    def __init__(self, bento_service: BentoService) -> None:
         self.service_name = bento_service.name
         self.version = bento_service.version
         self.namespace = config("instrument").get("default_namespace")
-        self.extra_labels_per_metric = defaultdict(list, extra_labels_per_metric)
-
-        self._exception_counter = self._create_metric(
-            Counter, "exception_total", "Total number of exceptions"
-        )
-
-        self._model_execution_duration = self._create_metric(
-            Histogram,
-            "model_execution_duration_seconds",
-            "Model execution duration in seconds",
-        )
-
-        self._model_execution_per_request_duration = self._create_metric(
-            Histogram,
-            "model_execution_per_request_duration_seconds",
-            "Model execution per request duration in seconds",
-        )
-
-        self._reward = self._create_metric(
-            Histogram, "reward", "Reward provided by feedback"
-        )
 
     def _create_metric(
         self,
@@ -50,14 +25,11 @@ class Monitor:
         documentation: Optional[str] = None,
         labelnames: Optional[List[str]] = None,
     ) -> MetricWrapperBase:
-        if labelnames is None:
-            labelnames = []
         labelnames = [
             "deployment_id",
             "service_version",
             "endpoint",
-            *self.extra_labels_per_metric[suffix],
-            *labelnames,
+            *(labelnames or []),
         ]
         return metric_class(
             name=f"{self.service_name}_{suffix}",
@@ -67,24 +39,44 @@ class Monitor:
         )
 
     def count_exceptions(
-        self, endpoint: str = PREDICT_ENDPOINT, extra_labels_values: list = []
+        self, endpoint: str = PREDICT_ENDPOINT, extra: Dict[str, Any] = {}
     ) -> ExceptionCounter:
+        if not hasattr(self, "_exception_counter"):
+            self._exception_counter = self._create_metric(
+                Counter, "exception_total", "Total number of exceptions", extra.keys()
+            )
+
         return self._exception_counter.labels(
-            DEPLOYMENT_ID, self.version, endpoint, *extra_labels_values
+            DEPLOYMENT_ID, self.version, endpoint, *extra.values()
         ).count_exceptions()
 
     def time_model_execution(
         self,
         parallel_executions: int,
         endpoint: str = PREDICT_ENDPOINT,
-        extra_labels_values: list = [],
+        extra: Dict[str, Any] = {},
     ) -> Timer:
+        if not hasattr(self, "_model_execution_duration"):
+            self._model_execution_duration = self._create_metric(
+                Histogram,
+                "model_execution_duration_seconds",
+                "Model execution duration in seconds",
+                extra.keys(),
+            )
+        if not hasattr(self, "_model_execution_per_request_duration"):
+            self._model_execution_per_request_duration = self._create_metric(
+                Histogram,
+                "model_execution_per_request_duration_seconds",
+                "Model execution per request duration in seconds",
+                extra.keys(),
+            )
+
         def observe(duration: float) -> None:
             self._model_execution_duration.labels(
-                DEPLOYMENT_ID, self.version, endpoint, *extra_labels_values
+                DEPLOYMENT_ID, self.version, endpoint, *extra.values()
             ).observe(duration)
             self._model_execution_per_request_duration.labels(
-                DEPLOYMENT_ID, self.version, endpoint, *extra_labels_values
+                DEPLOYMENT_ID, self.version, endpoint, *extra.values()
             ).observe(duration / parallel_executions)
 
         return Timer(observe)
@@ -93,8 +85,13 @@ class Monitor:
         self,
         value: float,
         endpoint: str = FEEDBACK_ENDPOINT,
-        extra_labels_values: list = [],
+        extra: Dict[str, Any] = {},
     ) -> None:
+        if not hasattr(self, "_reward"):
+            self._reward = self._create_metric(
+                Histogram, "reward", "Reward provided by feedback", extra.keys()
+            )
+
         self._reward.labels(
-            DEPLOYMENT_ID, self.version, endpoint, *extra_labels_values
+            DEPLOYMENT_ID, self.version, endpoint, *extra.values()
         ).observe(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "bento2seldon"
-version = "0.3.3"
+version = "0.3.4"
 description = "This project aims to combine the awesome capabilities of BentoML in packaging models with the powerful Seldon Core engine to deploy such models. It also features an optional cache using Redis that can also be used to make the feedback loop easier by using the request ID to get back the original request and response. For now, it was created for internal use and is in alpha state. But it will soon be prepared to be used by everyone."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Description

This pull request adds support for extra labels on Prometheus monitoring. This is and will be used for time-series segregation on different contexts (seller_ids on marketplaces, for example).

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [X] 🥂 Improvement (non-breaking change which improves an existing feature)
- [X] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [X] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/fernandocamargoai/bento2seldon/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I've read the [`CONTRIBUTING.md`](https://github.com/fernandocamargoai/bento2seldon/blob/master/CONTRIBUTING.md) guide.
- [X] I've updated the code style using `make codestyle`.
- [X] I've written tests for all new methods and classes that I created.
- [X] I've written the docstring in Google format for all the methods and classes that I used.
